### PR TITLE
Update web3.eth.pas

### DIFF
--- a/web3.eth.pas
+++ b/web3.eth.pas
@@ -219,9 +219,12 @@ begin
     Signer.Init(True, Param);
     Signature := Signer.GenerateSignature(sha3(TEncoding.UTF8.GetBytes(
       #25 + 'Ethereum Signed Message:' + #10 + IntToStr(Length(msg)) + msg)));
-    if chainId[chain] > 0 then
-      V := Signature.rec.Add(TBigInteger.ValueOf(chainId[chain] * 2 + 35))
-    else
+      // taking into consideration that we can calculate "V" without the chainID as described here 
+      // https://github.com/Nethereum/Nethereum/blob/master/src/Nethereum.Signer/EthECKey.cs#L217
+      // we can delete the lines commented out below and everything will work fine.
+//    if chainId[chain] > 0 then
+//      V := Signature.rec.Add(TBigInteger.ValueOf(chainId[chain] * 2 + 35))
+//    else
       V := Signature.rec.Add(TBigInteger.ValueOf(27));
     Result := toHex(Signature.r.ToByteArrayUnsigned + Signature.s.ToByteArrayUnsigned + V.ToByteArrayUnsigned);
   finally


### PR DESCRIPTION
using this test parameters
Private Key: 'b5b1870957d373ef0eeffecc6e4812c0fd08f554b37b233526acc331bf1544f7'
Message: 'wee test message 18/09/2017 02:55PM'

will produce a signature of
'0xF2ED5AF7EF0308108F4B143056D5D5FF53D3600107D21456B8C0CC82DE49DCD367E1A99ED76C50115F5162A55AA123CA4FB993A462E2E6B57B7E9F788A67CBB51C'

which verifies correctly on etherscan.io/verifySig using the below test address
address: '0x12890d2cce102216644c59dae5baed380d84830c'